### PR TITLE
feat: add activationCodeData type to ServerData interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,20 @@ export type ServerState = 'BASIC'
   | undefined;
 
 export interface ServerData {
+  activationCodeData?: {
+    __typename?: 'ActivationCode';
+    background?: string;
+    code?: string;
+    comment?: string;
+    header?: string;
+    headermetacolor?: string;
+    partnerName?: string;
+    partnerUrl?: string;
+    serverName?: string;
+    showBannerGradient?: boolean;
+    sysModel?: string;
+    theme?: string;
+  },
   description?: string;
   deviceCount?: number;
   expireTime?: number;


### PR DESCRIPTION
The "activate" callback into the purchase flow for automated activation submissions requires at least the activation code.

Related to https://github.com/unraid/api/pull/1369/